### PR TITLE
Table and Line Graph

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "emmet.excludeLanguages": [
+    "markdown"
+  ],
+
+  "emmet.includeLanguages": {
+    "javascript": "javascriptreact"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5456,6 +5456,32 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "chart.js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
+      "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "chokidar": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
@@ -9772,6 +9798,11 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
+    "leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -10315,6 +10346,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10582,6 +10618,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -12381,6 +12422,15 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-chartjs-2": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.10.0.tgz",
+      "integrity": "sha512-1MjWEkUn8LLFf6GVyYUOrruJTW3yVU5hlEJOwGj3MiokuC+jH/BahjWVGAMonbe9UYbEIUbd2Rn36iVlC0Hb7w==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -12586,6 +12636,27 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-leaflet": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-2.7.0.tgz",
+      "integrity": "sha512-pMf5eRyWU8RH9HohM2i0NZymcWHraJA1m6iMFYu94/01PAaBJpOyxORZJmN6cV9dBzkVWaLjAAHTNmxbwIpcfw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "fast-deep-equal": "^3.1.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "react-scripts": {
       "version": "3.4.3",
@@ -15076,6 +15147,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,13 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "chart.js": "^2.9.3",
+    "leaflet": "^1.7.1",
+    "numeral": "^2.0.6",
     "react": "^16.13.1",
+    "react-chartjs-2": "^2.10.0",
     "react-dom": "^16.13.1",
+    "react-leaflet": "^2.7.0",
     "react-scripts": "3.4.3"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -15,9 +15,30 @@ body {
   margin-bottom: 20px;
 }
 
+.app {
+  padding: 20px;
+}
+
+.app__left {
+  flex: 0.70;
+  margin-bottom: 20px;
+}
+
 .app__stats {
-display: flex;
-justify-content: space-between;
-align-items: center;
-padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+}
+
+.graph {
+  margin-top: 3rem;
+}
+
+@media (min-width: 990px) {
+
+  .app {
+    display: flex;
+    justify-content: space-evenly;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import { 
           FormControl,
+          FormControlLabel,
+          RadioGroup,
+          Radio,
           MenuItem,
-          Select
+          Select,
+          Card,
+          CardContent
           } from '@material-ui/core';
-import StatBox from './components/StatBox'
+import StatBox from './components/StatBox';
+import Table from './components/Table';
 import './App.css';
+import Graph from './components/Graph';
 
 function App() {
   const [countries, setCountries] = useState([]);
   const [country, setCountry] = useState("global");
   const [countryInfo, setCountryInfo] = useState({})
+  const [tableData, setTableData] = useState([])
+  const [caseType, setCaseType] = useState('cases')
   
   useEffect(() => {
     const fetchData = async() => {
@@ -19,19 +28,20 @@ function App() {
       setCountryInfo(response)
     }
     fetchData();
-  }, [])
+  }, []);
 
   useEffect(() => {
-const getCountries = async () => {
- const response = await (await fetch('https://disease.sh/v3/covid-19/countries'))
- const res = await response.json()
- const countries = res.map((country) => ({
-   name: country.country,
-   value: country.countryInfo.iso2
-  }));
- setCountries(countries);
-}
-getCountries()
+  const getCountries = async () => {
+    const response = await (await fetch('https://disease.sh/v3/covid-19/countries'))
+    const res = await response.json()
+    const countries = res.map((country) => ({
+      name: country.country,
+      value: country.countryInfo.iso2
+      }));
+    setCountries(countries);
+    setTableData(res.sort((a, b) =>  b.cases - a.cases))
+  }
+    getCountries()
   }, [])
 
   const onCountryChange =  async (e) => {
@@ -50,27 +60,51 @@ getCountries()
   }
   return (
     <div className="app">
-      <div className="app__header  ">
-        <h1> Covid 19 Tracker</h1>
-        <FormControl className="app__dropdown">
-        <Select 
-          variant="outlined"
-          value={country}
-          onChange={onCountryChange}
-        >
-          <MenuItem value="global">Global</MenuItem>
-          {
-            countries.map((country) => (
-              <MenuItem value={country.value}>{country.name}</MenuItem>
-            ))
-          }
-        </Select>
-      </FormControl>
-      </div>
-      <div className="app__stats">
-        <StatBox title='Confirmed Cases' cases={countryInfo.todayCases} total={countryInfo.cases} />
+      <div className="app__left">
+        <div className="app__header  ">
+          <h1> Covid 19 Tracker</h1>
+          <FormControl className="app__dropdown">
+          <Select 
+            variant="outlined"
+            value={country}
+            onChange={onCountryChange}
+          >
+            <MenuItem value="global">Global</MenuItem>
+            {
+              countries.map((country) => (
+                <MenuItem value={country.value}>{country.name}</MenuItem>
+              ))
+            }
+          </Select>
+        </FormControl>
+        </div>
+        <div className="app__stats">
+        <StatBox title='Confirmed' cases={countryInfo.todayCases} total={countryInfo.cases} />
         <StatBox title='Recovered' cases={countryInfo.todayRecovered} total={countryInfo.recovered} />
         <StatBox title='Deaths' cases={countryInfo.todayDeaths} total={countryInfo.deaths} />
+      </div>
+      </div>
+      <div className="app__right">
+        <Card>
+          <CardContent>
+            <h3>Table</h3>
+            <Table countries={tableData} /> 
+
+            <div className="graph">
+              <h3>New Cases</h3>
+              <FormControl component="fieldset">
+                <RadioGroup aria-label="gender" name="gender1" value={caseType} onChange={(e) => setCaseType(e.target.value)} row>
+                  <FormControlLabel value="cases" control={<Radio />} label="Confirmed" />
+                  <FormControlLabel value="recovered" control={<Radio />} label="Recovered" />
+                  <FormControlLabel value="deaths" control={<Radio />} label="Deaths" />
+                </RadioGroup>
+              </FormControl>
+              <Graph caseType={caseType}
+                    country={country}
+              />
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react'
+import { Line } from 'react-chartjs-2'
+import numeral from 'numeral'
+import fetchGraphData from '../utils/graphUtil';
+
+const options = {
+  legend: {
+    display: false,
+  },
+  elements: {
+    point: {
+      radius: 0,
+    },
+  },
+  maintainAspectRatio: false,
+  tooltips: {
+    mode: "index",
+    intersect: false,
+    callbacks: {
+      label: function (tooltipItem, data) {
+        return numeral(tooltipItem.value).format("+0,0");
+      },
+    },
+  },
+  scales: {
+    xAxes: [
+      {
+        type: "time",
+        time: {
+          format: "MM/DD/YY",
+          tooltipFormat: "ll",
+        },
+      },
+    ],
+    yAxes: [
+      {
+        gridLines: {
+          display: false,
+        },
+        ticks: {
+          // Include a dollar sign in the ticks
+          callback: function (value, index, values) {
+            return numeral(value).format("0a");
+          },
+        },
+      },
+    ],
+  },
+};
+function Graph({ caseType, country }) {
+  const [graphData, setGraphData] = useState([]);
+
+  useEffect(() => {
+    const fetchdata = async() => {
+      const url = country === 'global' ? "https://disease.sh/v3/covid-19/historical/all?lastdays=30" : `https://disease.sh/v3/covid-19/historical/${country}?lastdays=30`
+      const data = await fetch(url)
+      const jsonData = await data.json()
+      await setGraphData(fetchGraphData(jsonData, caseType));
+    }
+    fetchdata();
+  }, [caseType, country])
+  return (
+    <div className="graph">
+
+      <Line
+        data={{
+          datasets: [
+            {
+              data: graphData,
+              backgroundColor: "rgba(204, 16, 52, 0.5)",
+              borderColor: "#CC1034"
+            }
+          ]
+        }}
+        options= {options}
+      />
+    </div>
+  )
+}
+
+export default Graph

--- a/src/components/StatBox.js
+++ b/src/components/StatBox.js
@@ -10,10 +10,10 @@ function StatBox({title, cases, total}) {
             {title}
           </Typography>
           <Typography className="infobox_title" color="textSecondary">
-            {cases}
+            Today: {cases}
           </Typography>
           <Typography className="infobox_title" color="textSecondary">
-            {total}
+            Total: {total}
           </Typography>
         </CardContent>
       </Card>

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import '../styles/table.css'
+
+function Table({countries}) {
+  return (
+    <div className="table">
+      {countries.map(({country, cases}) => (
+        <tr>
+          <td>{country}</td>
+          <td><strong>{cases}</strong></td>
+        </tr>
+      ))}
+    </div>
+  )
+}
+
+export default Table

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -1,0 +1,19 @@
+.table {
+  height: 500px;
+  overflow-y: scroll;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+tr {
+  display: flex;
+  justify-content: space-between;
+}
+
+td {
+  padding: 1rem;
+}
+
+.table tr:nth-of-type(odd) {
+  background-color: rgb(218, 214, 214);
+}

--- a/src/utils/graphUtil.js
+++ b/src/utils/graphUtil.js
@@ -1,0 +1,16 @@
+export default (data, caseType = 'cases') => {
+  let res = []
+  let previousData;
+  const info = data[caseType] || data['timeline'][caseType]
+  for (let date in info) {
+    if (previousData) {
+      const newData = {
+        x: date,
+        y: (info[date] - previousData)
+      }
+      res.push(newData)
+    }
+    previousData = info[date]
+  }
+  return res
+}


### PR DESCRIPTION
## This PR displays the distribution of COVID-19 infection using a table and graph

### Implementations
-  Display a table of countries with the most cases
-  Display a graph that shows the distribution of confirmed cases, recovered patients, and deaths over a period of 30 days

### How to test
- clone this repo `git clone git@github.com:OlawaleJoseph/covid-info.git` and cd into it
- checkout into header branch `git checkout header`
- Open a terminal and run `npm install`
- After successful installation, run `yarn start`
- Select a country in the upper right corner of the page
- Check the table on the top right corner of the page
- View the graph on the bottom right corner of the page, change the options(confirmed, recovered, deaths)
![graph_table](https://user-images.githubusercontent.com/46751363/92660357-2b426380-f2f2-11ea-85ac-e9e2bb6af0f4.png)
